### PR TITLE
Work-around for margin

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -234,7 +234,7 @@ input, select, textarea {
 
 	.container {
 		margin: 0 auto;
-		max-width: 100%;
+		max-width: 98%;
 		width: 1200px;
 	}
 


### PR DESCRIPTION
Your container values are fixed pixel sizes from what I can tell, that's a big nono- what if they're on a phone? Because the positions are relative to their parents (there's like 4 wrapper divs) and I don't know how to change this position without breaking all of the hard coded stuff - I just made it 98% max-width to add what 'feels' like a little bit of breathing room.